### PR TITLE
yesod-auth-json.md: reset verkey in verifyAccount

### DIFF
--- a/cookbook/yesod-auth-json.md
+++ b/cookbook/yesod-auth-json.md
@@ -160,7 +160,7 @@ instance YesodAuthEmail App where
        case mu of
          Nothing -> return Nothing
          Just u -> do
-           update uid [UserVerified =. True]
+           update uid [UserVerified =. True, UserVerkey =. Nothing]
            return $ Just uid
   getPassword = runDB . fmap (join . fmap userPassword) . get
   setPassword uid pass = runDB $ update uid [UserPassword =. Just pass]


### PR DESCRIPTION
I'm not 100 % sure but it seems to be what these 2 links suggest:
* https://github.com/yesodweb/yesod/issues/1222
* https://www.stackage.org/haddock/lts-13.2/yesod-auth-1.6.6/Yesod-Auth-Email.html#v:verifyAccount